### PR TITLE
Per-user saved jobs fixed + polished Jobs UI with styling and tests

### DIFF
--- a/__tests__/adzuna.test.ts
+++ b/__tests__/adzuna.test.ts
@@ -1,0 +1,51 @@
+import { searchJobs } from "../src/utils/adzuna";
+
+declare const global: any;
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
+test("searchJobs returns parsed results", async () => {
+  const payload = {
+    results: [
+      {
+        id: 123,
+        title: "Dev",
+        company: { display_name: "Acme" },
+        location: { display_name: "NYC" },
+        created: "2025-01-01",
+        redirect_url: "http://x",
+      },
+      {
+        id: 456,
+        title: "QA",
+        company: { display_name: "Beta" },
+        location: { display_name: "SF" },
+        created: "2025-02-02",
+        redirect_url: "http://y",
+      },
+    ],
+  };
+
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => payload,
+  });
+
+  const data = await searchJobs("software", 1);
+  expect(Array.isArray(data)).toBe(true);
+  expect(data).toHaveLength(2);
+  // spot-check a field that should round-trip
+  expect(String(data[0].id)).toBe("123");
+});
+
+test("searchJobs throws if fetch fails", async () => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: false,
+    status: 500,
+    json: async () => ({ error: "boom" }),
+  });
+
+  await expect(searchJobs("software", 1)).rejects.toBeTruthy();
+});

--- a/app/Login.tsx
+++ b/app/Login.tsx
@@ -41,14 +41,13 @@ export default function Login() {
         (u: any) => u.username === username && u.password === password
       );
       if (user) {
-        await login("someTokenValue", user.username, user.password); // Replace "someTokenValue" with a real token if you have one
-        setFeedback("Login successful! Welcome back!");
+        // Tell AuthContext who is logged in
+        await login("someTokenValue", user.username, user.password);
 
         await AsyncStorage.setItem("currentUser", JSON.stringify(user));
         await AsyncStorage.setItem("isLoggedIn", "true");
 
         setFeedback("Login successful! Welcome back!");
-
         setTimeout(() => {
           router.replace("/Home");
         }, 1500);

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -9,7 +9,15 @@ export default function RootLayout() {
     <AuthProvider>
       <SavedJobsProvider>
         <AuthGate>
-          <Stack />
+          <Stack>
+            <Stack.Screen name="index" options={{ headerTitle: "Index" }} />
+            <Stack.Screen name="Home" options={{ headerTitle: "Home" }} />
+            <Stack.Screen name="jobs" options={{ headerTitle: "Jobs" }} />
+            <Stack.Screen name="savedJobs" options={{ headerTitle: "Saved Jobs" }} />
+            <Stack.Screen name="Login" options={{ headerTitle: "Login" }} />
+            <Stack.Screen name="Register" options={{ headerTitle: "Register" }} />
+            <Stack.Screen name="debug" options={{ headerTitle: "Debug" }} />
+          </Stack>
         </AuthGate>
       </SavedJobsProvider>
     </AuthProvider>

--- a/app/jobs.tsx
+++ b/app/jobs.tsx
@@ -1,3 +1,4 @@
+import { Ionicons } from "@expo/vector-icons";
 import { useLocalSearchParams, useRouter } from "expo-router";
 import { useEffect, useState } from "react";
 import {
@@ -12,6 +13,18 @@ import {
 } from "react-native";
 import { useSavedJobs } from "../src/utils/SavedJobsContext";
 import { AdzunaJob, searchJobs } from "../src/utils/adzuna";
+
+const PALETTE = {
+  bg: "#FFFFFF",
+  text: "#00171F",
+  subtext: "#4B5563",
+  primary: "#00A7E1",
+  teal: "#007EA7",
+  cardBorder: "#DCE8F2",
+  muted: "#6B7280",
+  chipBg: "#E6F7FD",
+};
+
 type JobCard = {
   id: string;
   title: string;
@@ -21,6 +34,14 @@ type JobCard = {
   url?: string;
 };
 
+async function openJobUrl(url?: string) {
+  if (!url) return;
+  try {
+    const can = await Linking.canOpenURL(url);
+    if (can) await Linking.openURL(url);
+  } catch {}
+}
+
 export default function JobsScreen() {
   const { q } = useLocalSearchParams<{ q?: string }>();
   const query = (Array.isArray(q) ? q[0] : q) || "software";
@@ -28,7 +49,7 @@ export default function JobsScreen() {
   const [jobs, setJobs] = useState<JobCard[]>([]);
   const [loading, setLoading] = useState(false);
   const router = useRouter();
-  const { add, isSaved } = useSavedJobs();
+  const { add, remove, isSaved } = useSavedJobs();
 
   useEffect(() => {
     (async () => {
@@ -36,7 +57,7 @@ export default function JobsScreen() {
         setLoading(true);
         const results: AdzunaJob[] = await searchJobs(query, 1);
         const mapped: JobCard[] = results.map((j) => ({
-          id: j.id,
+          id: String(j.id),
           title: j.title,
           company: j.company?.display_name ?? "Unknown",
           location: j.location?.display_name ?? "Unknown",
@@ -52,63 +73,87 @@ export default function JobsScreen() {
       }
     })();
   }, [query]);
+
   return (
     <SafeAreaView style={s.screen}>
       <View style={s.wrap}>
-        {/* Navbar */}
-        <View style={s.row}>
+        {/* Top bar */}
+        <View style={s.topRow}>
           <Text style={s.h1}>Job Listings</Text>
           <Pressable style={s.pill} onPress={() => router.push("/savedJobs")}>
             <Text style={s.pillText}>Saved Jobs</Text>
           </Pressable>
         </View>
 
-        {/* small hint showing the current query */}
-        <View style={s.input}>
-          <Text style={s.muted}>Showing results for: {query}</Text>
+        <View style={{ height: 12 }} />
+
+        {/* Query chip */}
+        <View style={s.chipRow}>
+          <View style={s.chip}>
+            <Text style={s.chipText}>Category: {query}</Text>
+          </View>
         </View>
 
         <ScrollView contentContainerStyle={{ paddingBottom: 28 }}>
-          {loading && (
-            <Text style={{ color: "#6b7280", marginBottom: 10 }}>Loading…</Text>
-          )}
+          {loading && <Text style={s.muted}>Loading…</Text>}
 
-          {jobs.map((item) => (
-            <View key={item.id} style={s.card}>
-              <Text style={s.title}>{item.title}</Text>
-              <Text style={s.sub}>
-                {item.company} • {item.location}
-              </Text>
-              <Text style={s.body}>
-                <TouchableOpacity
-                  onPress={() => Linking.openURL(item.url || "underfined")}
-                >
-                  <Text style={{ color: "#0ea5a4" }}>Apply!</Text>
-                </TouchableOpacity>
-              </Text>
+          {jobs.map((item) => {
+            const saved = isSaved(item.id);
+            return (
+              <View key={item.id} style={s.card}>
+                <Text style={s.title}>{item.title}</Text>
+                <Text style={s.sub}>
+                  {item.company} • {item.location}
+                </Text>
 
-              <View style={s.cardRow}>
-                <Pressable
-                  onPress={() => add(item)}
-                  disabled={isSaved(item.id)}
-                  style={[
-                    s.btn,
-                    isSaved(item.id) && { backgroundColor: "#9CA3AF" },
-                  ]}
-                >
-                  <Text style={s.btnText}>
-                    {isSaved(item.id) ? "♥︎" : "♡"}
-                  </Text>
-                </Pressable>
+                <View style={s.actionsRow}>
+                  <TouchableOpacity
+                    onPress={() => openJobUrl(item.url)}
+                    disabled={!item.url}
+                    style={[s.linkBtn, !item.url && { opacity: 0.4 }]}
+                  >
+                    <Text style={s.linkBtnText}>
+                      {item.url ? "Apply" : "No link"}
+                    </Text>
+                  </TouchableOpacity>
+                </View>
+
                 <Text style={s.posted}>
                   Posted: {item.postedAt ? item.postedAt.slice(0, 10) : "—"}
                 </Text>
+
+                {/* Heart LAST so it stacks on top and is fully clickable */}
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel={saved ? "Unsave job" : "Save job"}
+                  onPress={() =>
+                    saved
+                      ? remove(item.id)
+                      : add({
+                          id: item.id,
+                          title: item.title,
+                          company: item.company,
+                          location: item.location,
+                          url: item.url,
+                          postedAt: item.postedAt,
+                        })
+                  }
+                  hitSlop={{ top: 6, bottom: 6, left: 6, right: 6 }}
+                  style={s.heartBtn}
+                  testID={`heart-${item.id}`}
+                >
+                  <Ionicons
+                    name={saved ? "heart" : "heart-outline"}
+                    size={22}
+                    color={saved ? "#e11d48" : "#9CA3AF"}
+                  />
+                </Pressable>
               </View>
-            </View>
-          ))}
+            );
+          })}
 
           {!loading && jobs.length === 0 && (
-            <Text style={{ color: "#6b7280" }}>No results.</Text>
+            <Text style={s.muted}>No results.</Text>
           )}
         </ScrollView>
       </View>
@@ -117,62 +162,98 @@ export default function JobsScreen() {
 }
 
 const s = StyleSheet.create({
-  screen: { flex: 1, backgroundColor: "#f4f6f8" },
+  screen: { flex: 1, backgroundColor: PALETTE.bg },
   wrap: { flex: 1, padding: 16 },
-  row: {
+
+  topRow: {
     flexDirection: "row",
     alignItems: "center",
     justifyContent: "space-between",
   },
-  h1: { fontSize: 22, fontWeight: "800" },
+  h1: { fontSize: 22, fontWeight: "800", color: PALETTE.text },
 
   pill: {
-    backgroundColor: "#0ea5a4",
-    paddingHorizontal: 12,
-    paddingVertical: 8,
+    backgroundColor: PALETTE.primary,
+    paddingHorizontal: 14,
+    paddingVertical: 10,
     borderRadius: 12,
+    shadowColor: "#000",
+    shadowOpacity: 0.15,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 2,
   },
-  pillText: { color: "#ffffff", fontWeight: "700" },
+  pillText: { color: "#fff", fontWeight: "700" },
 
-  input: {
-    height: 42,
-    borderRadius: 12,
-    backgroundColor: "#ffffff",
+  chipRow: { flexDirection: "row", gap: 8, marginTop: 6, marginBottom: 10 },
+  chip: {
+    backgroundColor: PALETTE.chipBg,
+    borderColor: PALETTE.primary,
     borderWidth: 1,
-    borderColor: "#d1fae5",
-    paddingHorizontal: 12,
-    justifyContent: "center",
-    marginTop: 10,
-    marginBottom: 12,
+    paddingHorizontal: 10,
+    paddingVertical: 6,
+    borderRadius: 999,
   },
-  muted: { color: "#6b7280" },
+  chipText: { color: PALETTE.teal, fontWeight: "600" },
 
   card: {
-    backgroundColor: "#ffffff",
+    position: "relative", 
+    backgroundColor: "#fff",
     borderRadius: 16,
     padding: 14,
+    paddingTop: 16,
     marginBottom: 12,
     borderWidth: 1,
-    borderColor: "#d1fae5",
-    borderLeftWidth: 4,
-    borderLeftColor: "#2dd4bf",
+    borderColor: PALETTE.cardBorder,
+    shadowColor: "#000",
+    shadowOpacity: 0.06,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 1,
   },
-  title: { fontSize: 16, fontWeight: "700", color: "#0f172a" },
-  sub: { marginTop: 2, color: "#6b7280" },
-  body: { marginTop: 8, color: "#1f2937" },
 
-  cardRow: {
+  heartBtn: {
+    position: "absolute",
+    top: 10,
+    right: 10,
+    zIndex: 10,
+    width: 44,
+    height: 44,
+    borderRadius: 22,
+    backgroundColor: "#ffffff",
+    justifyContent: "center",
+    alignItems: "center",
+    shadowColor: "#000",
+    shadowOpacity: 0.1,
+    shadowRadius: 6,
+    shadowOffset: { width: 0, height: 2 },
+    elevation: 4,
+  },
+
+  title: {
+    fontSize: 16,
+    fontWeight: "700",
+    color: PALETTE.text,
+    paddingRight: 48, 
+  },
+  sub: { marginTop: 2, color: PALETTE.subtext, paddingRight: 48 },
+
+  actionsRow: {
     marginTop: 12,
     flexDirection: "row",
-    justifyContent: "space-between",
+    gap: 10,
     alignItems: "center",
   },
-  btn: {
-    backgroundColor: "#0ea5a4",
-    paddingHorizontal: 12,
+
+  linkBtn: {
+    backgroundColor: PALETTE.teal,
+    paddingHorizontal: 14,
     paddingVertical: 8,
     borderRadius: 10,
   },
-  btnText: { color: "#ffffff", fontWeight: "700" },
-  posted: { color: "#6b7280", width: 96, textAlign: "right" },
+  linkBtnText: { color: "#fff", fontWeight: "700" },
+
+  posted: { marginTop: 10, color: PALETTE.muted, textAlign: "right" },
+  muted: { color: PALETTE.muted, marginTop: 8 },
 });
+

--- a/app/savedJobs.tsx
+++ b/app/savedJobs.tsx
@@ -1,15 +1,33 @@
 import { useRouter } from "expo-router";
 import React, { useCallback } from "react";
-import { FlatList, Linking, Pressable, Text, TouchableOpacity, View } from "react-native";
+import {
+  FlatList,
+  Linking,
+  Pressable,
+  SafeAreaView,
+  StyleSheet,
+  Text,
+  TouchableOpacity,
+  View,
+} from "react-native";
 import { useSavedJobs } from "../src/utils/SavedJobsContext";
+
+const PALETTE = {
+  bg: "#FFFFFF",
+  text: "#00171F",
+  subtext: "#4B5563",
+  primary: "#00A7E1",
+  navy: "#003459",
+  danger: "#B00020",
+  cardBorder: "#DCE8F2",
+};
 
 async function openJobUrl(url?: string) {
   if (!url) return;
   try {
     const can = await Linking.canOpenURL(url);
     if (can) await Linking.openURL(url);
-  } catch {
-  }
+  } catch {}
 }
 
 export default function SavedJobsScreen() {
@@ -18,41 +36,22 @@ export default function SavedJobsScreen() {
 
   const renderItem = useCallback(
     ({ item }: any) => (
-      <View
-        style={{
-          marginHorizontal: 16,
-          marginVertical: 8,
-          padding: 12,
-          borderWidth: 1,
-          borderRadius: 10,
-        }}
-      >
-        <Text style={{ fontWeight: "bold", fontSize: 16 }}>{item.title}</Text>
-        {!!item.company && <Text>{item.company}</Text>}
-        {!!item.location && <Text>{item.location}</Text>}
+      <View style={s.card}>
+        <Text style={s.title}>{item.title}</Text>
+        {!!item.company && <Text style={s.sub}>{item.company}</Text>}
+        {!!item.location && <Text style={s.sub}>{item.location}</Text>}
 
-        <View style={{ flexDirection: "row", gap: 16, marginTop: 10 }}>
+        <View style={s.actionsRow}>
           {item.url ? (
-            <Pressable onPress={() => openJobUrl(item.url)}>
-              <Text style={{ color: "#0ea5a4", textDecorationLine: "underline" }}>
-                View Job Posting
-              </Text>
+            <Pressable onPress={() => openJobUrl(item.url)} style={s.linkBtn}>
+              <Text style={s.linkBtnText}>View Posting</Text>
             </Pressable>
           ) : (
-            <Text style={{ opacity: 0.6 }}>No direct link</Text>
+            <Text style={[s.sub, { opacity: 0.7 }]}>No direct link</Text>
           )}
 
-          <TouchableOpacity
-            onPress={() => remove(item.id)}
-            style={{
-              paddingHorizontal: 12,
-              paddingVertical: 8,
-              borderWidth: 1,
-              borderRadius: 8,
-              marginLeft: "auto",
-            }}
-          >
-            <Text>Remove</Text>
+          <TouchableOpacity onPress={() => remove(item.id)} style={s.removeBtn}>
+            <Text style={s.removeBtnText}>Remove</Text>
           </TouchableOpacity>
         </View>
       </View>
@@ -61,33 +60,77 @@ export default function SavedJobsScreen() {
   );
 
   return (
-    <View style={{ flex: 1 }}>
-      <View
-        style={{
-          paddingHorizontal: 16,
-          paddingVertical: 12,
-          borderBottomWidth: 1,
-          flexDirection: "row",
-          alignItems: "center",
-        }}
-      >
-        <Pressable onPress={() => router.back()}>
-          <Text style={{ textDecorationLine: "underline" }}>‹ Back</Text>
-        </Pressable>
-        <Text style={{ marginLeft: 12, fontSize: 18, fontWeight: "600" }}>
-          Saved Jobs
-        </Text>
-      </View>
-
+    <SafeAreaView style={s.screen}>
       <FlatList
+        contentContainerStyle={{ padding: 16 }}
         data={saved}
         keyExtractor={(item) => item.id}
         ListEmptyComponent={
-          <Text style={{ textAlign: "center", marginTop: 24 }}>No saved jobs yet.</Text>
+          <Text style={[s.sub, { textAlign: "center", marginTop: 24 }]}>
+            No saved jobs yet.
+          </Text>
         }
         renderItem={renderItem}
       />
-    </View>
+    </SafeAreaView>
   );
 }
+
+const s = StyleSheet.create({
+  screen: { flex: 1, backgroundColor: PALETTE.bg },
+  header: {
+    paddingHorizontal: 16,
+    paddingVertical: 12,
+    borderBottomWidth: 1,
+    borderColor: PALETTE.cardBorder,
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+  },
+  back: { color: PALETTE.primary, fontWeight: "700" },
+  h1: { fontSize: 18, fontWeight: "800", color: PALETTE.text },
+
+  card: {
+    backgroundColor: "#fff",
+    borderRadius: 16,
+    padding: 14,
+    marginBottom: 12,
+    borderWidth: 1,
+    borderColor: PALETTE.cardBorder,
+    shadowColor: "#000",
+    shadowOpacity: 0.06,
+    shadowRadius: 8,
+    shadowOffset: { width: 0, height: 3 },
+    elevation: 1,
+  },
+  title: { fontSize: 16, fontWeight: "700", color: PALETTE.text },
+  sub: { marginTop: 2, color: PALETTE.subtext },
+
+  actionsRow: {
+    marginTop: 12,
+    flexDirection: "row",
+    alignItems: "center",
+    gap: 10,
+  },
+
+  linkBtn: {
+    backgroundColor: PALETTE.primary,
+    paddingHorizontal: 14,
+    paddingVertical: 8,
+    borderRadius: 10,
+  },
+  linkBtnText: { color: "#fff", fontWeight: "700" },
+
+  removeBtn: {
+    marginLeft: "auto",
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    borderRadius: 10,
+    borderWidth: 1,
+    borderColor: PALETTE.cardBorder,
+    backgroundColor: "#FFF5F6",
+  },
+  removeBtnText: { color: PALETTE.danger, fontWeight: "600" },
+});
+
 

--- a/context/AuthProvider.tsx
+++ b/context/AuthProvider.tsx
@@ -73,3 +73,5 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     </AuthContext.Provider>
   );
 };
+
+export const useAuth = () => React.useContext(AuthContext);

--- a/src/utils/SavedJobsContext.tsx
+++ b/src/utils/SavedJobsContext.tsx
@@ -1,62 +1,104 @@
 import AsyncStorage from "@react-native-async-storage/async-storage";
-import React, { createContext, useContext, useEffect, useMemo, useState } from "react";
+import React, { createContext, useContext, useEffect, useMemo, useRef, useState } from "react";
+import { useAuth } from "../../context/AuthProvider";
 
 export type SavedJob = {
   id: string;
   title: string;
-  company?: string;
-  location?: string;
+  company: string;
+  location: string;
   postedAt?: string;
   url?: string;
 };
 
-type SavedJobsCtx = {
+type Ctx = {
   saved: SavedJob[];
   add: (job: SavedJob) => void;
   remove: (id: string) => void;
-  isSaved: (id: string | number) => boolean;
+  isSaved: (id: string) => boolean;
+  clearInMemory: () => void;
 };
 
-const SavedJobsContext = createContext<SavedJobsCtx | null>(null);
-const STORAGE_KEY = "SAVED_JOBS_V1";
+const C = createContext<Ctx | null>(null);
+
+const keyFor = (identity: string | null) => `SAVED_JOBS_V3_${identity ?? "GUEST"}`;
+
+async function resolveIdentity(usernameFromAuth: string | null): Promise<string | null> {
+  if (usernameFromAuth) return usernameFromAuth; // preferred: from AuthProvider
+  // fallback: what Login/Register already save
+  try {
+    const raw = await AsyncStorage.getItem("currentUser");
+    if (raw) {
+      const u = JSON.parse(raw);
+      return String(u?.username ?? u?.id ?? "");
+    }
+  } catch {}
+  return null;
+}
 
 export function SavedJobsProvider({ children }: { children: React.ReactNode }) {
+  const { username } = useAuth(); 
+  const [identity, setIdentity] = useState<string | null>(null);
   const [saved, setSaved] = useState<SavedJob[]>([]);
-  const [hydrated, setHydrated] = useState(false);
+  const [loadedKey, setLoadedKey] = useState<string | null>(null);
+  const loadingRef = useRef(false);
 
+  // 1) Figuring out who the user is whenever auth changes
   useEffect(() => {
+    let cancelled = false;
     (async () => {
+      const who = await resolveIdentity(username ?? null);
+      if (!cancelled) setIdentity(who && who.length ? who : null);
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [username]);
+
+  // 2) Loading the user's saved jobs on identity change/app start
+  useEffect(() => {
+    const key = keyFor(identity);
+    let cancelled = false;
+    (async () => {
+      loadingRef.current = true;
       try {
-        const raw = await AsyncStorage.getItem(STORAGE_KEY);
-        if (raw) setSaved(JSON.parse(raw));
-      } catch {
+        const raw = await AsyncStorage.getItem(key);
+        if (!cancelled) {
+          setSaved(raw ? JSON.parse(raw) : []);
+          setLoadedKey(key);
+        }
       } finally {
-        setHydrated(true);
+        loadingRef.current = false;
       }
     })();
-  }, []);
+    return () => {
+      cancelled = true;
+    };
+  }, [identity]);
 
+  // 3) Persisting whenever the list changes
   useEffect(() => {
-    if (!hydrated) return;
-    AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(saved)).catch(() => {});
-  }, [saved, hydrated]);
+    if (!loadedKey || loadingRef.current) return;
+    AsyncStorage.setItem(loadedKey, JSON.stringify(saved)).catch(() => {});
+  }, [saved, loadedKey]);
 
-  const api = useMemo<SavedJobsCtx>(() => {
-    return {
+  const api = useMemo<Ctx>(
+    () => ({
       saved,
       add: (job) =>
-        setSaved((prev) => (prev.find((j) => j.id === job.id) ? prev : [job, ...prev])),
-      remove: (id) => setSaved((prev) => prev.filter((j) => j.id !== String(id))),
-      isSaved: (id) => saved.some((j) => j.id === String(id)),
-    };
-  }, [saved, hydrated]);
+        setSaved((prev) => (prev.some((j) => j.id === job.id) ? prev : [job, ...prev])),
+      remove: (id) => setSaved((prev) => prev.filter((j) => j.id !== id)),
+      isSaved: (id) => saved.some((j) => j.id === id),
+      clearInMemory: () => setSaved([]),
+    }),
+    [saved]
+  );
 
-  return <SavedJobsContext.Provider value={api}>{children}</SavedJobsContext.Provider>;
+  return <C.Provider value={api}>{children}</C.Provider>;
 }
 
 export function useSavedJobs() {
-  const ctx = useContext(SavedJobsContext);
-  if (!ctx) throw new Error("useSavedJobs must be used within SavedJobsProvider");
+  const ctx = useContext(C);
+  if (!ctx) throw new Error("useSavedJobs must be used inside SavedJobsProvider");
   return ctx;
 }
-


### PR DESCRIPTION
- Auth
  - Exported `useAuth()` from context/AuthProvider for easy access to username/token
  - Register now calls `login(...)` after creating a user; Login continues to call `login(...)`

- Jobs page UX/UI
  - Styled to team palette (white bg, #00A7E1 primary, #00171F text, etc.)
  - Kept query chip showing the active category

- Saved Jobs page UI
  - Styled cards, improved spacing, added clear “View Posting” and “Remove” actions

- Tests
  - Updated jobs.test to match new UI (chip, heart toggle via testID)
  - Added savedJobs.test to verify hydrate/add/remove/isSaved with user-scoped storage
  - Added adzuna.test (happy path + error path with mocked fetch)
  - Test setup: mock Linking + AsyncStorage to avoid native warnings
